### PR TITLE
Fix the location of driver configuration page

### DIFF
--- a/modules/ROOT/content-nav.adoc
+++ b/modules/ROOT/content-nav.adoc
@@ -72,7 +72,7 @@
 *** xref:ogm/type-generation.adoc[]
 *** xref:ogm/reference.adoc[]
 
-*** xref:driver-configuration.adoc[]
+** xref:driver-configuration.adoc[]
 
 ** Frameworks and integrations
 *** xref:integrations/apollo-federation.adoc[]


### PR DESCRIPTION
Driver configuration is currently wrongly under the OGM chapter.