### PR TITLE
Add documentation on CDC Engine for subscriptions

### DIFF
--- a/modules/ROOT/pages/subscriptions/engines.adoc
+++ b/modules/ROOT/pages/subscriptions/engines.adoc
@@ -24,6 +24,47 @@ new Neo4jGraphQL({
 This behavior enables a simple subscription system that works on a single instance.
 It is ideal for development, testing, and servers that do not require horizontal scaling.
 
+[[CDC]]
+== Change Data Capture (Beta)
+
+If your database supports Change Data Capture (CDC), you can use it as your mechanism for subscriptions using `Neo4jGraphQLSubscriptionsCDCEngine`. Make sure to follow the steps on link:https://neo4j.com/docs/cdc/current/[CDC Documentation] to enable it for your Neo4j instance.
+
+CDC-based subscriptions behave differently from other subscription mechanisms, as this uses the native CDC events from Neo4j database. This has the following implications:
+
+* Any database change, including those changes done outside of GraphQL will be reported.
+* Relationship events are not supported at the moment.
+* No additional broker mechanism is required, all the events are received by all the instances of `@neo4j/graphql`.
+* Events are not triggered immediately but are polled to the database.
+
+=== Usage
+
+The `Neo4jGraphQLSubscriptionsCDCEngine` can be imported directly from the library. The Neo4j driver is the only required argument:
+
+[souce, javascript, indent=0]
+----
+import { Neo4jGraphQL, Neo4jGraphQLSubscriptionsCDCEngine } from '@neo4j/graphql';
+
+const engine = new Neo4jGraphQLSubscriptionsCDCEngine({
+    driver,
+})
+
+const neoSchema = new Neo4jGraphQL({
+    typeDefs,
+    driver,
+    features: {
+        subscriptions: engine,
+    },
+});
+----
+
+
+=== API
+The following options can be passed to the constructor:
+
+* **driver**: The driver to be used for CDC queries.
+* **pollTime**: The interval, in milliseconds, between queries to CDC. Defaults to 100ms. Note that poll time is the period between one request finishing and the next one starting. The actual time it takes for CDC events to trigger the subscription will also depend on your network.
+* **queryConfig**: An object with the driver query options to be passed to CDC requests. Use the **db** field to define the target db for CDC. 
+
 [[amqp]]
 == AMQP
 


### PR DESCRIPTION
Adds documentation on support for [CDC](https://neo4j.com/docs/cdc/current/) on subscriptions, added on the version 4.4.0 of the library

