### PR TITLE
Adds how to add session and transaction to the execution context

### DIFF
--- a/modules/ROOT/pages/driver-configuration.adoc
+++ b/modules/ROOT/pages/driver-configuration.adoc
@@ -76,6 +76,73 @@ await startStandaloneServer(server, {
 
 ----
 
+==== Session in context
+
+[source, javascript, indent=0]
+----
+import { ApolloServer } from "@apollo/server";
+import { startStandaloneServer } from "@apollo/server/standalone";
+import { Neo4jGraphQL } from "@neo4j/graphql";
+import neo4j from "neo4j-driver";
+
+const typeDefs = `#graphql
+    type User {
+        name: String
+    }
+`;
+
+const driver = neo4j.driver(
+    "bolt://localhost:7687",
+    neo4j.auth.basic("neo4j", "password")
+);
+const session = driver.session();
+
+const neoSchema = new Neo4jGraphQL({ typeDefs, driver });
+
+const server = new ApolloServer({
+    schema: await neoSchema.getSchema(),
+});
+
+await startStandaloneServer(server, {
+    context: async ({ req }) => ({ req, executionContext: session }),
+});
+
+----
+
+==== Transaction in context
+
+[source, javascript, indent=0]
+----
+import { ApolloServer } from "@apollo/server";
+import { startStandaloneServer } from "@apollo/server/standalone";
+import { Neo4jGraphQL } from "@neo4j/graphql";
+import neo4j from "neo4j-driver";
+
+const typeDefs = `#graphql
+    type User {
+        name: String
+    }
+`;
+
+const driver = neo4j.driver(
+    "bolt://localhost:7687",
+    neo4j.auth.basic("neo4j", "password")
+);
+const session = driver.transaction();
+const transaction = session.beginTransaction();
+
+const neoSchema = new Neo4jGraphQL({ typeDefs, driver });
+
+const server = new ApolloServer({
+    schema: await neoSchema.getSchema(),
+});
+
+await startStandaloneServer(server, {
+    context: async ({ req }) => ({ req, executionContext: transaction }),
+});
+
+----
+
 === OGM
 
 [source, javascript, indent=0]


### PR DESCRIPTION
A very small docs change to give two more examples in the driver-configuration page, where we now show how to pass `session` and `transaction` to the execution context