### PR TITLE
docs: removes aggregate defaulting to false note

### DIFF
--- a/modules/ROOT/pages/schema-configuration/field-configuration.adoc
+++ b/modules/ROOT/pages/schema-configuration/field-configuration.adoc
@@ -95,12 +95,6 @@ directive @relationship(
 ) on FIELD_DEFINITION
 ----
 
-[NOTE]
-====
-In version 4.0.0, `aggregate` is `false` as default.
-See xref:migration/v4-migration/index.adoc#_relationship_changes[`@relationship changes`] for more information.
-====
-
 === Usage
 
 *Configure aggregation*


### PR DESCRIPTION
This was not actually the case, the default for aggregate is true.