### PR TITLE
update playbook config

### DIFF
--- a/publish.yml
+++ b/publish.yml
@@ -30,9 +30,6 @@ antora:
     move_sitemaps_to_components: true
   - require: "@neo4j-antora/aliases-redirects"
     redirect_format: neo4j
-    redirect_map:
-    - from: '4'
-      to: 'current'
 
 asciidoc:
   extensions:


### PR DESCRIPTION
The latest version o the aliases-redirects extension compares all the versions of the content that are included in the playbook. Starting with the earliest and working to the current version, it generates suggested redirects from page-aliases based on the changes from version `n` to version `n+1`.

It also removed all redirect pages that Antora automatically creates (except for the redirect that points to the `start_page` specified in the playbook, so eg `localhost:8000` still redirects to the index page when running local preview).