### PR TITLE
Add missing code line in indexes and constraints example

### DIFF
--- a/modules/ROOT/pages/type-definitions/directives/indexes-and-constraints.adoc
+++ b/modules/ROOT/pages/type-definitions/directives/indexes-and-constraints.adoc
@@ -232,7 +232,7 @@ This creates two constraints, one for each field decorated with `@id` and `@uniq
 [source, javascript, indent=0]
 ----
 const typeDefs = `#graphql
-    type Colour {
+    type Color {
         id: ID! @id
         hexadecimal: String! @unique
     }

--- a/modules/ROOT/pages/type-definitions/directives/indexes-and-constraints.adoc
+++ b/modules/ROOT/pages/type-definitions/directives/indexes-and-constraints.adoc
@@ -245,5 +245,7 @@ const typeDefs = `#graphql
 
 const neoSchema = new Neo4jGraphQL({ typeDefs, driver });
 
+const schema = await neoSchema.getSchema();
+
 await neoSchema.assertIndexesAndConstraints({ options: { create: true }});
 ----


### PR DESCRIPTION
You need to call `getSchema()` before `assertIndexesAndConstraints`