### PR TITLE
Update filtering examples by using `_EQ`  and add migration guide

### DIFF
--- a/modules/ROOT/pages/migration/index.adoc
+++ b/modules/ROOT/pages/migration/index.adoc
@@ -96,6 +96,42 @@ query {
 
 == Deprecations and warnings
 
+=== Implicit equality filters are deprecated
+
+Implicit equality filters such as: 
+
+  - `{ name: "Keanu" }`
+  - `{ count: 10 }` 
+
+Are deprecated in favor of `{ name_EQ: "Keanu" }` and `{ count_EQ: 10 }` respectively and will be removed in the next major version.
+
+[cols="1,1"]
+|===
+|Before | Now
+
+a|
+[source, graphql, indent=0]
+----
+query {
+  users(where: { name: "John" }) {
+    id
+    name
+  }
+}
+----
+a|
+[source, graphql, indent=0]
+----
+query {
+  users(where: { name_EQ: "John" }) {
+    id
+    name
+  }
+}
+----
+|===
+
+
 === `@node` will have to be explicitly defined
 
 In the future, types without the `@node` directive will no longer be treated as Neo4j nodes.

--- a/modules/ROOT/pages/migration/index.adoc
+++ b/modules/ROOT/pages/migration/index.adoc
@@ -54,7 +54,7 @@ a|
 [source, graphql, indent=0]
 ----
 query {
-  movies(where: { NOT: { title: "The Matrix" } }) {
+  movies(where: { NOT: { title_EQ: "The Matrix" } }) {
     title
   }
 }
@@ -78,7 +78,7 @@ a|
 [source, graphql, indent=0]
 ----
 query {
-  movies(where: { actors_NOT: { name: "Keanu" } }) {
+  movies(where: { actors_NOT: { name_EQ: "Keanu" } }) {
     title
   }
 }
@@ -87,7 +87,7 @@ a|
 [source, graphql, indent=0]
 ----
 query {
-  movies(where: { actors_NONE: { name: "Keanu" } }) {
+  movies(where: { actors_NONE: { name_EQ: "Keanu" } }) {
     title
   }
 }

--- a/modules/ROOT/pages/migration/index.adoc
+++ b/modules/ROOT/pages/migration/index.adoc
@@ -59,6 +59,42 @@ query {
 
 == Deprecations and warnings
 
+=== Implicit equality filters are deprecated
+
+Implicit equality filters such as: 
+
+  - `{ name: "Keanu" }`
+  - `{ count: 10 }` 
+
+Are deprecated in favor of `{ name_EQ: "Keanu" }` and `{ count_EQ: 10 }` respectively and will be removed in the next major version.
+
+[cols="1,1"]
+|===
+|Before | Now
+
+a|
+[source, graphql, indent=0]
+----
+query {
+  users(where: { name: "John" }) {
+    id
+    name
+  }
+}
+----
+a|
+[source, graphql, indent=0]
+----
+query {
+  users(where: { name_EQ: "John" }) {
+    id
+    name
+  }
+}
+----
+|===
+
+
 === `@node` will have to be explicitly defined
 
 In the future, types without the `@node` directive will no longer be treated as Neo4j nodes.

--- a/modules/ROOT/pages/migration/index.adoc
+++ b/modules/ROOT/pages/migration/index.adoc
@@ -98,12 +98,13 @@ query {
 
 === Implicit equality filters are deprecated
 
-Implicit equality filters such as: 
+The following implicit equality filters are deprecated: 
 
   - `{ name: "Keanu" }`
   - `{ count: 10 }` 
 
-Are deprecated in favor of `{ name_EQ: "Keanu" }` and `{ count_EQ: 10 }` respectively and will be removed in the next major version.
+You can achieve the same by using `{ name_EQ: "Keanu" }` and `{ count_EQ: 10 }`.
+The deprecated quality filters will be removed in version 7.x.
 
 [cols="1,1"]
 |===

--- a/modules/ROOT/pages/mutations/create.adoc
+++ b/modules/ROOT/pages/mutations/create.adoc
@@ -140,7 +140,7 @@ mutation {
     name: "Tom Hanks",
     movies: {
       connectOrCreate: {
-        where: { node: { id: "1234" } }
+        where: { node: { id_EQ: "1234" } }
         onCreate: { node: { title: "Forrest Gump" } }
       }
     }

--- a/modules/ROOT/pages/mutations/delete.adoc
+++ b/modules/ROOT/pages/mutations/delete.adoc
@@ -49,7 +49,7 @@ A single post can be deleted by executing the following GraphQL statement:
 ----
 mutation {
     deletePosts(where: {
-        id: "6042E807-47AE-4857-B7FE-1AADF522DE8B"
+        id_EQ: "6042E807-47AE-4857-B7FE-1AADF522DE8B"
     }) {
         nodesDeleted
         relationshipsDeleted
@@ -67,7 +67,7 @@ In case you want to delete a `User` *and* all of their posts, you can use a sing
 [source, graphql, indent=0]
 ----
 mutation {
-  deleteUsers(where: { name: "Jane Doe" }, delete: { posts: {} }) {
+  deleteUsers(where: { name_EQ: "Jane Doe" }, delete: { posts: {} }) {
     nodesDeleted
     relationshipsDeleted
   }
@@ -82,14 +82,14 @@ Essentially, the above query is equivalent to:
 mutation {
     deleteUsers(
         where: {
-            name: "Jane Doe"
+            name_EQ: "Jane Doe"
         },
         delete: {
             posts: [
                 where: {
                     node: {
                         creator: {
-                            name: "Jane Doe"
+                            name_EQ: "Jane Doe"
                         }
                     }
                 }

--- a/modules/ROOT/pages/mutations/update.adoc
+++ b/modules/ROOT/pages/mutations/update.adoc
@@ -59,7 +59,7 @@ The content of a `Post` can be updated by executing the following GraphQL statem
 mutation {
     updatePosts(
         where: {
-            id: "892CC104-A228-4BB3-8640-6ADC9F2C2A5F"
+            id_EQ: "892CC104-A228-4BB3-8640-6ADC9F2C2A5F"
         }
         update: {
             content: "Some new content for this Post!"
@@ -82,7 +82,7 @@ Instead of creating a `Post` with the `create` mutation and then connecting it t
 ----
 mutation {
     updateUsers(
-        where: { name: "John Doe" }
+        where: { name_EQ: "John Doe" }
         update: {
             posts: {
                 create: [
@@ -113,7 +113,7 @@ mutation {
     name: "Tom Hanks",
     movies: {
       connectOrCreate: {
-        where: { node: { id: "1234" } }
+        where: { node: { id_EQ: "1234" } }
         onCreate: { node: { title: "Forrest Gump" } }
       }
     }
@@ -134,12 +134,12 @@ mutation {
       update: {
         movies: {
             connectOrCreate: {
-                where: { node: { id: "1234" } }
+                where: { node: { id_EQ: "1234" } }
                 onCreate: { node: { title: "Forrest Gump" } }
             }
         }
       },
-      where: { name: "Tom Hanks" }
+      where: { name_EQ: "Tom Hanks" }
   ) {
     info {
       nodesCreated
@@ -462,7 +462,7 @@ Here is how you can do that:
 ----
 mutation incrementViewCountMutation {
   updateVideos(
-    where: { id: "VideoID" }
+    where: { id_EQ: "VideoID" }
     update: { views_INCREMENT: 1 }
   ) {
     videos {
@@ -480,7 +480,7 @@ To do that, you have to update the relationship property `revenue`:
 ----
 mutation addRevenueMutation {
   updateUsers(
-    where: { id: "UserID" },
+    where: { id_EQ: "UserID" },
     update: { ownVideo: [{ update: { edge: { revenue_ADD: 0.01 } } }] }
   ) {
     users {

--- a/modules/ROOT/pages/queries-aggregations/filtering.adoc
+++ b/modules/ROOT/pages/queries-aggregations/filtering.adoc
@@ -30,7 +30,7 @@ query {
                 ]
             },
             {
-                movies_SOME: { title: "The Matrix" }
+                movies_SOME: { title_EQ: "The Matrix" }
             }
         ]}
     ) {
@@ -54,7 +54,7 @@ For example:
 [source, graphql, indent=0]
 ----
 query {
-  users(where: {name: "John" })
+  users(where: { name_EQ: "John" })
     id
     name
   }
@@ -66,7 +66,7 @@ For non-equality, you must use the xref:/queries-aggregations/filtering.adoc#_bo
 [source, graphql, indent=0]
 ----
 query {
-  users(where: { NOT: {name: "John" }})
+  users(where: { NOT: { name_EQ: "John" }})
     id
     name
   }
@@ -376,7 +376,7 @@ For example:
 [source, graphql, indent=0]
 ----
 query {
-    posts(where: { author: { id: "7CF1D9D6-E527-4ACD-9C2A-207AE0F5CB8C" } }) {
+    posts(where: { author: { id_EQ: "7CF1D9D6-E527-4ACD-9C2A-207AE0F5CB8C" } }) {
         content
     }
 }
@@ -386,7 +386,7 @@ query {
 [source, graphql, indent=0]
 ----
 query {
-    posts(where: { NOT: { author: { id: "7CF1D9D6-E527-4ACD-9C2A-207AE0F5CB8C" } } }) {
+    posts(where: { NOT: { author: { id_EQ: "7CF1D9D6-E527-4ACD-9C2A-207AE0F5CB8C" } } }) {
         content
     }
 }

--- a/modules/ROOT/pages/queries-aggregations/pagination/cursor-based.adoc
+++ b/modules/ROOT/pages/queries-aggregations/pagination/cursor-based.adoc
@@ -24,7 +24,7 @@ If you wanted to fetch the posts of user "John Smith" 10 at a time, you would fi
 [source, graphql, indent=0]
 ----
 query {
-    users(where: { name: "John Smith" }) {
+    users(where: { name_EQ: "John Smith" }) {
         name
         postsConnection(first: 10) {
             edges {
@@ -46,7 +46,7 @@ In the return value, if `hasNextPage` is `true`, you would pass `endCursor` into
 [source, graphql, indent=0]
 ----
 query Users($after: String) {
-    users(where: { name: "John Smith" }) {
+    users(where: { name_EQ: "John Smith" }) {
         name
         postsConnection(first: 10, after: $after) {
             edges {
@@ -72,7 +72,7 @@ The Connection fields also offer a `totalCount` field which can be used to calcu
 [source, graphql, indent=0]
 ----
 query Users($after: String) {
-    users(where: { name: "John Smith" }) {
+    users(where: { name_EQ: "John Smith" }) {
         name
         postsConnection(first: 10) {
             edges {

--- a/modules/ROOT/pages/queries-aggregations/pagination/offset-based.adoc
+++ b/modules/ROOT/pages/queries-aggregations/pagination/offset-based.adoc
@@ -72,7 +72,7 @@ Say that in addition to the `User` type above, there is also a `Post` type which
 ----
 query {
     users(where: {
-        name: "Billy"
+        name_EQ: "Billy"
     }) {
         name
         posts(options: {

--- a/modules/ROOT/pages/queries-aggregations/queries.adoc
+++ b/modules/ROOT/pages/queries-aggregations/queries.adoc
@@ -60,7 +60,7 @@ query {
 [source, graphql, indent=0]
 ----
 query {
-    users(where: { name: "Jane Smith" }) {
+    users(where: { name_EQ: "Jane Smith" }) {
         id
         name
         posts {

--- a/modules/ROOT/pages/security/authorization.adoc
+++ b/modules/ROOT/pages/security/authorization.adoc
@@ -34,7 +34,7 @@ type User @node {
 }
 
 type Post @node @authorization(filter: [
-    { where: { node: { author: { id: "$jwt.sub" } } } }
+    { where: { node: { author: { id_EQ: "$jwt.sub" } } } }
 ]) {
     title: String!
     content: String!
@@ -58,7 +58,7 @@ For instance, to only require filtering for the reading and aggregating posts:
 [source, graphql, indent=0]
 ----
 type Post @node @authorization(filter: [
-    { operations: [READ, AGGREGATE] where: { node: { author: { id: "$jwt.sub" } } } }
+    { operations: [READ, AGGREGATE] where: { node: { author: { id_EQ: "$jwt.sub" } } } }
 ]) {
     title: String!
     content: String!
@@ -87,7 +87,7 @@ type JWT @jwt {
 }
 
 type User @node @authorization(validate: [
-    { where: { node: { id: "$jwt.sub" } } }
+    { where: { node: { id_EQ: "$jwt.sub" } } }
     { where: { jwt: { roles_INCLUDES: "admin" } } }
 ]) {
     id: ID!
@@ -112,7 +112,7 @@ For instance, to only require validation for the update or deletion of a post:
 [source, graphql, indent=0]
 ----
 type Post @node @authorization(validate: [
-    { operations: [UPDATE, DELETE] where: { node: { author: { id: "$jwt.sub" } } } }
+    { operations: [UPDATE, DELETE] where: { node: { author: { id_EQ: "$jwt.sub" } } } }
 ]) {
     title: String!
     content: String!
@@ -140,8 +140,8 @@ type User @node {
 }
 
 type Post @node @authorization(filter: [
-    { where: { node: { author: { id: "$jwt.sub" } } } }
-    { requireAuthentication: false, operations: [READ], where: { node: { public: true } } }
+    { where: { node: { author: { id_EQ: "$jwt.sub" } } } }
+    { requireAuthentication: false, operations: [READ], where: { node: { public_EQ: true } } }
 ]) {
     title: String!
     content: String!

--- a/modules/ROOT/pages/security/operations.adoc
+++ b/modules/ROOT/pages/security/operations.adoc
@@ -63,7 +63,7 @@ For single `delete` mutations, rules with `DELETE` on the object are evaluated:
 [source, graphql, indent=0]
 ----
 mutation {
-    deleteMovies(where: { title: "The Matrix" }) { # DELETE ON OBJECT Movie
+    deleteMovies(where: { title_EQ: "The Matrix" }) { # DELETE ON OBJECT Movie
         nodesDeleted
     }
 }
@@ -75,8 +75,8 @@ For `delete` mutations with nested delete operations, rules with operation `DELE
 ----
 mutation {
     deleteMovies(                                                  # DELETE ON OBJECT Movie
-        where: { title: "The Matrix" }
-        delete: { actors: { where: { node: { name: "Keanu" } } } } # DELETE ON OBJECT Actor
+        where: { title_EQ: "The Matrix" }
+        delete: { actors: { where: { node: { name_EQ: "Keanu" } } } } # DELETE ON OBJECT Actor
     ) { 
         nodesDeleted
     }
@@ -89,8 +89,8 @@ For a complex `update` mutation with many effects, a variety of rules is evaluat
 ----
 mutation {
     updateMovies(
-        where: { title: "The Matrix" }
-        connect: { actors: { where: { node: { name: "Keanu" } } } } # CONNECT ON OBJECT Actor and Movie
+        where: { title_EQ: "The Matrix" }
+        connect: { actors: { where: { node: { name_EQ: "Keanu" } } } } # CONNECT ON OBJECT Actor and Movie
         update: {                                                   # UPDATE ON OBJECT Movie
             title: "Speed"                                          # UPDATE ON FIELD_DEFINITION Movie.title
         }

--- a/modules/ROOT/pages/security/subscriptions-authorization.adoc
+++ b/modules/ROOT/pages/security/subscriptions-authorization.adoc
@@ -19,7 +19,7 @@ For instance, here is how to filter out `User` events which don't match the JWT 
 [source, graphql, indent=0]
 ----
 type User @node @subscriptionsAuthorization(filter: [
-    { where: { node: { id: "$jwt.sub" } } }
+    { where: { node: { id_EQ: "$jwt.sub" } } }
 ]) {
     id: ID!
 }
@@ -40,7 +40,7 @@ For instance, to only require filtering for mutations to a type itself and not i
 [source, graphql, indent=0]
 ----
 type User @node @subscriptionsAuthorization(filter: [
-    { events: [CREATED, UPDATED, DELETED], where: { node: { id: "$jwt.sub" } } }
+    { events: [CREATED, UPDATED, DELETED], where: { node: { id_EQ: "$jwt.sub" } } }
 ]) {
     id: ID!
 }
@@ -56,7 +56,7 @@ For instance, in the case where some `Post` nodes are private whilst other `Post
 [source, graphql, indent=0]
 ----
 type Post @node @subscriptionsAuthorization(filter: [
-    { requireAuthentication: false, where: { node: { public: true } } }
+    { requireAuthentication: false, where: { node: { public_EQ: true } } }
 ]) {
     title: String!
     content: String!

--- a/modules/ROOT/pages/subscriptions/events.adoc
+++ b/modules/ROOT/pages/subscriptions/events.adoc
@@ -1389,7 +1389,7 @@ mutation {
 mutation { 
     deleteMovies(
         where: {
-            title: "John Wick"
+            title_EQ: "John Wick"
         }
     ) {
         nodesDeleted
@@ -1490,7 +1490,7 @@ mutation {
 mutation { 
     deleteMovies(
         where: {
-            title: "New York Stories"
+            title_EQ: "New York Stories"
         }
     ) {
         nodesDeleted
@@ -1667,7 +1667,7 @@ mutation {
 mutation { 
     deleteMovies(
         where: {
-            title: "Sweeney Todd"
+            title_EQ: "Sweeney Todd"
         }
     ) {
         nodesDeleted

--- a/modules/ROOT/pages/subscriptions/filtering.adoc
+++ b/modules/ROOT/pages/subscriptions/filtering.adoc
@@ -90,7 +90,7 @@ To filter subscriptions to `create` operations for movies by their genre, here i
 [source, graphql, indent=0]
 ----
 subscription {
-    movieCreated(where: {genre: "Drama"}) {
+    movieCreated(where: { genre_EQ: "Drama" }) {
         createdMovie {
             title
         }
@@ -112,7 +112,7 @@ Here is how to filter subscription to `update` operations in movies with average
 [source, graphql, indent=0]
 ----
 subscription {
-    movieUpdate(where: {averageRating_GT: 8}) {
+    movieUpdate(where: { averageRating_GT: 8 }) {
         updatedMovie {
             title
         }
@@ -144,14 +144,14 @@ mutation {
 
 mutation {
     updateTheMatrix: updateMovie(
-        where: {title: "The Matrix"}
-        update: {averageRating: 7.9}
+        where: { title_EQ: "The Matrix" }
+        update: { averageRating: 7.9 }
     ) {
         title
     },
     updateResurrections: updateMovie(
-        where: {title: "The Matrix Resurrections"}
-        update: {averageRating: 8.9}
+        where: { title_EQ: "The Matrix Resurrections" }
+        update: { averageRating: 8.9 }
     ) {
         title
     }
@@ -167,7 +167,7 @@ Here is how to filter subscription to `delete` operations in movies by their gen
 [source, graphql, indent=0]
 ----
 subscription {
-    movieDeleted(where: { NOT: { genre: "Comedy" } }) {
+    movieDeleted(where: { NOT: { genre_EQ: "Comedy" } }) {
         deletedMovie {
             title
         }
@@ -197,9 +197,9 @@ subscription {
     movieUpdated(where: {
         OR: [
             { title_CONTAINS: "Matrix" },
-            { genre: "comedy" },
+            { genre_EQ: "comedy" },
             { AND: [ 
-                { NOT: { genre: "romantic comedy" } },
+                { NOT: { genre_EQ: "romantic comedy" } },
                 { releasedIn_GT: 2000 },
                 { releasedIn_LTE: 2005 }
             ] },
@@ -280,7 +280,7 @@ The following example filters the subscriptions to newly created relationships t
 [source, graphql, indent=0]
 ----
 subscription {
-    movieRelationshipCreated(where: { movie: { NOT: { genre: "Drama" } }, createdRelationship: { actors: { edge: { screenTime_GT: 10 } } } }) {
+    movieRelationshipCreated(where: { movie: { NOT: { genre_EQ: "Drama" } }, createdRelationship: { actors: { edge: { screenTime_GT: 10 } } } }) {
         movie {
             title
         }
@@ -308,7 +308,7 @@ The following example filters the subscriptions to deleted relationships that we
 [source, graphql, indent=0]
 ----
 subscription {
-    movieRelationshipDeleted(where: { movie: { genre_IN: ["Comedy", "Adventure"] }, createdRelationship: { actors: { node: { name: "Jim Carrey" } } } }) {
+    movieRelationshipDeleted(where: { movie: { genre_IN: ["Comedy", "Adventure"] }, createdRelationship: { actors: { node: { name_EQ: "Jim Carrey" } } } }) {
         movie {
             title
         }
@@ -480,7 +480,7 @@ If you are also interested in the relationship itself conforming to some filters
                     screenTime_LT: 40, 
                 }
                 node: { 
-                    name: "Alvin"
+                    name_EQ: "Alvin"
                 }
             } 
         }
@@ -614,8 +614,8 @@ This example illustrates how to filter the node at the other end of the relation
                         year_GT: 2010
                     },
                     node: {
-                        name: "John Doe",
-                        reputation: 10
+                        name_EQ: "John Doe",
+                        reputation_EQ: 10
                     }
                 },
                 Actor: { # concrete type that makes up the union type
@@ -623,7 +623,7 @@ This example illustrates how to filter the node at the other end of the relation
                         year_LT: 2005
                     },
                     node: {
-                        name: "Tom Hardy"
+                        name_EQ: "Tom Hardy"
                     }
                 }
             }, 
@@ -697,7 +697,7 @@ One reason why this might be done is to include some filters on the `Actor` type
             directors: { 
                 Actor: { # include some relationships of type `DIRECTED` to an `Actor` type, that conform to the filters
                     node: {
-                        NOT: { name: "Tom Hardy" }
+                        NOT: { name_EQ: "Tom Hardy" }
                     }
                 }
             }
@@ -716,7 +716,7 @@ To include filters on the `Actor` type, but also include the `Person` type in th
             directors: { 
                 Actor: { # include some relationships of type `DIRECTED` to an `Actor` type, that conform to the filters
                     node: {
-                        NOT: { name: "Tom Hardy" }
+                        NOT: { name_EQ: "Tom Hardy" }
                     }
                 },
                 Person: {} # include all relationships of type `DIRECTED` to a `Person` type

--- a/modules/ROOT/pages/subscriptions/getting-started.adoc
+++ b/modules/ROOT/pages/subscriptions/getting-started.adoc
@@ -147,7 +147,7 @@ You can subscribe to new movies created with the following statement:
 [source, graphql, indent=0]
 ----
 subscription {
-    movieCreated(where: { title: "The Matrix" }) {
+    movieCreated(where: { title_EQ: "The Matrix" }) {
         createdMovie {
             title
         }
@@ -161,7 +161,7 @@ You can try this with the following query:
 [source, graphql, indent=0]
 ----
 mutation {
-    createMovies(input: [{ title: "The Matrix" }]) {
+    createMovies(input: [{ title_EQ: "The Matrix" }]) {
         movies {
             title
         }

--- a/modules/ROOT/pages/troubleshooting.adoc
+++ b/modules/ROOT/pages/troubleshooting.adoc
@@ -197,7 +197,7 @@ Then delete the director node:
 [source, graphql, indent=0]
 ----
 mutation {
-  deletePeople(where: { name: "Robert Zemeckis" }) {
+  deletePeople(where: { name_EQ: "Robert Zemeckis" }) {
     nodesDeleted
   }
 }

--- a/modules/ROOT/pages/types/interfaces.adoc
+++ b/modules/ROOT/pages/types/interfaces.adoc
@@ -152,11 +152,11 @@ Take the following example:
 ----
 mutation CreateActorAndProductions {
     updateActors(
-        where: { name: "Woody Harrelson" }
+        where: { name_EQ: "Woody Harrelson" }
         connect: {
             actedIn: {
-                where: { node: { title: "Zombieland" } }
-                connect: { actors: { where: { node: { name: "Emma Stone" } } } }
+                where: { node: { title_EQ: "Zombieland" } }
+                connect: { actors: { where: { node: { name_EQ: "Emma Stone" } } } }
             }
         }
     ) {

--- a/modules/ROOT/pages/types/relationships.adoc
+++ b/modules/ROOT/pages/types/relationships.adoc
@@ -193,7 +193,7 @@ mutation CreateActor {
             actedInMovies: {
                 connect: {
                     where: {
-                        node: { title: "Forrest Gump" }
+                        node: { title_EQ: "Forrest Gump" }
                     }
                     edge: {
                         roles: ["Forrest"]
@@ -288,7 +288,7 @@ Now that you have the `Movie` information in your database, you can query everyt
 [source, graphql, indent=0]
 ----
 query {
-    movies(where: { title: "Forrest Gump" }) {
+    movies(where: { title_EQ: "Forrest Gump" }) {
         title
         released
         director {

--- a/modules/ROOT/pages/types/scalar.adoc
+++ b/modules/ROOT/pages/types/scalar.adoc
@@ -38,7 +38,7 @@ a|
 [source, graphql, indent=0]
 ----
 query {
-    files(where: { size: 9223372036854775807 }) {
+    files(where: { size_EQ: 9223372036854775807 }) {
         size
     }
 }

--- a/modules/ROOT/pages/types/spatial.adoc
+++ b/modules/ROOT/pages/types/spatial.adoc
@@ -57,7 +57,7 @@ For example, you can query for a `User` with an exact location:
 [source, graphql, indent=0]
 ----
 query Users($longitude: Float!, $latitude: Float!) {
-    users(where: { location: { longitude: $longitude, latitude: $latitude } }) {
+    users(where: { location_EQ: { longitude: $longitude, latitude: $latitude } }) {
         name
         location {
             longitude

--- a/modules/ROOT/pages/types/unions.adoc
+++ b/modules/ROOT/pages/types/unions.adoc
@@ -96,7 +96,7 @@ While this particular query only returns blogs, you could for instance use a fil
 query GetUsersWithAllContent {
     users {
         name
-        content(where: { Blog: { NOT: { title: null } }}) {
+        content(where: { Blog: { NOT: { title_EQ: null } }}) {
             ... on Blog {
                 title
             }


### PR DESCRIPTION
As title, this PR describe the addition and the deprecation that has made to migrate from the `{ title: "The Matrix" }` to `{ title_EQ: "The Matrix" }`

Branched from #194 , review and merge that before this.