### PR TITLE
[Cherry-pick][6.x] Use secret instead of github_token (#209)

### DIFF
--- a/.github/workflows/auto-backport.yml
+++ b/.github/workflows/auto-backport.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Cherry-pick action
         uses: sorenlouv/backport-github-action@929f69d04adbc196d982e60f02837b6cc00b3129
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+          github_token: ${{ secrets.DOCS_AUTO_CP_TOKEN }}
           auto_backport_label_prefix: auto-cherry-pick-to-
           add_original_reviewers: true
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `5.x` to `6.x`:
 - [Use secret instead of github_token (#209)](https://github.com/neo4j/docs-graphql/pull/209)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)