### PR TITLE
Add breaking change on invalid sort

### DIFF
--- a/modules/ROOT/pages/migration/index.adoc
+++ b/modules/ROOT/pages/migration/index.adoc
@@ -319,8 +319,8 @@ Removed the `@cypher` fields not usable as sort fields from the `sort` argument.
 
 There were some circumstances where a `@cypher` field was incorrectly present in the `sort` argument, such as:
 
-  - `@cypher` fields with no-nullable arguments.
-  - `@cypher` fields with not sortable type like `Node`, `List` etc ... .
+  - `@cypher` fields with non nullable arguments.
+  - `@cypher` fields with non sortable type like `Node`, `List` etc ... .
 
 
 == Additions

--- a/modules/ROOT/pages/migration/index.adoc
+++ b/modules/ROOT/pages/migration/index.adoc
@@ -315,12 +315,10 @@ The following fields have been added:
 
 === Removed some `@cypher` fields from the sort argument
 
-Removed the `@cypher` fields not usable as sort fields from the `sort` argument.
+The following `@cypher` field types have been removed from the `sort` argument because they are not usable as sort fields:
 
-There were some circumstances where a `@cypher` field was incorrectly present in the `sort` argument, such as:
-
-  - `@cypher` fields with non nullable arguments.
-  - `@cypher` fields with non sortable type like `Node`, `List` etc ... .
+  - `@cypher` fields with non-nullable arguments.
+  - `@cypher` fields with non-sortable type like `Node`, `List` etc.
 
 
 == Additions

--- a/modules/ROOT/pages/migration/index.adoc
+++ b/modules/ROOT/pages/migration/index.adoc
@@ -313,6 +313,16 @@ The following fields have been added:
   - `deprecatedOptionsArgument`
   - `directedArgument`
 
+=== Removed some `@cypher` fields from the sort argument
+
+Removed the `@cypher` fields not usable as sort fields from the `sort` argument.
+
+There were some circumstances where a `@cypher` field was incorrectly present in the `sort` argument, such as:
+
+  - `@cypher` fields with no-nullable arguments.
+  - `@cypher` fields with not sortable type like `Node`, `List` etc ... .
+
+
 == Additions
 
 === Added the `_EQ` filter as an alternative to the deprecated implicit equal filters


### PR DESCRIPTION
Add breaking changes about `@cypher` fields be removed from the schema on the sort argument when these are no sortable.