### PR TITLE
[Cherry-pick][7.x] Merge pull request #182 from neo4j/update-vector-docs

### DIFF
--- a/modules/ROOT/pages/directives/index.adoc
+++ b/modules/ROOT/pages/directives/index.adoc
@@ -112,7 +112,7 @@ Particularly useful for types that are not correctly pluralized or are non-Engli
 | Indicates that there should be a uniqueness constraint in the database for the fields that it is applied to.
 
 | xref::/directives/indexes-and-constraints.adoc#_vector_index_search[`@vector`]
-| Perform a vector index search on your database either based by passing in a vector index or a search phrase. label:beta[]
+| Perform a vector index search on your database either based by passing in a vector index or a search phrase.
 
 |===
 

--- a/modules/ROOT/pages/directives/indexes-and-constraints.adoc
+++ b/modules/ROOT/pages/directives/indexes-and-constraints.adoc
@@ -248,7 +248,6 @@ await neoSchema.assertIndexesAndConstraints();
 
 :description: Directives related to generative AI in the Neo4j GraphQL Library.
 
-[role=label--beta]
 == Vector index search
 
 With the `@vector` GraphQL directive you can query your database to perform a vector index search.
@@ -331,15 +330,13 @@ This defines the query to be performed on all `Product` nodes which have a vecto
 ----
 query FindSimilarProducts($vector: [Float]!) {
   searchByDescription(vector: $vector) {
-    productsConnection {
-      edges {
-        cursor
-        score
-        node {
-            id
-            name
-            description
-        }
+    edges {
+      cursor
+      score
+      node {
+          id
+          name
+          description
       }
     }
   }
@@ -415,15 +412,13 @@ This defines the query to be performed on all `Product` nodes which have a vecto
 ----
 query SearchProductsByPhrase($phrase: String!) {
   searchByPhrase(phrase: $phrase) {
-    productsConnection {
-      edges {
-        cursor
-        score
-        node {
-            id
-            name
-            description
-        }
+    edges {
+      cursor
+      score
+      node {
+          id
+          name
+          description
       }
     }
   }


### PR DESCRIPTION
# Backport

This will backport the following commits from `5.x` to `7.x`:
 - [Merge pull request #182 from neo4j/update-vector-docs](https://github.com/neo4j/docs-graphql/pull/182)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)