### PR TITLE
[Cherry-pick][6.x] Merge pull request #230 from MacondoExpress/fix-limit-doc

### DIFF
--- a/modules/ROOT/pages/directives/custom-logic.adoc
+++ b/modules/ROOT/pages/directives/custom-logic.adoc
@@ -310,7 +310,7 @@ Available on nodes, this directive injects values into a query such as the `limi
 directive @limit(
     default: Int
     max: Int
-) on OBJECT
+) on OBJECT | INTERFACE
 ----
 
 === Usage
@@ -327,11 +327,8 @@ If no `default` value is set, `max` is used for queries without limit.
 
 [source, graphql, indent=0]
 ----
-{
-  Movie @limit(amount: 5) {
-    title
-    year
-  }
+type Movie @limit(max: 100, default: 10) @node {
+    id: ID
 }
 ----
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `5.x` to `6.x`:
 - [Merge pull request #230 from MacondoExpress/fix-limit-doc](https://github.com/neo4j/docs-graphql/pull/230)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)