### PR TITLE
[Cherry-pick][7.x] Merge pull request #221 from neo4j/update-cdc-docs

### DIFF
--- a/modules/ROOT/pages/subscriptions/customize-cdc.adoc
+++ b/modules/ROOT/pages/subscriptions/customize-cdc.adoc
@@ -19,7 +19,9 @@ Defaults to 1000ms.
 Note that poll time is the period between a finished request and the start of the next. 
 The actual time it takes for CDC events to trigger the subscription also depends on your network.
 * `queryConfig`: An object with the driver query options to be passed to CDC requests. 
-Use the `db` field to define the target database for CDC. 
+Use the `db` field to define the target database for CDC.
+* `onlyGraphQLEvents`: By default, subscriptions capture all changes done to the database. If this flag is set to true, only changes made through GraphQL will trigger the subscription.
+    * Note: If this flag is set to true, changes made with a different version of the `@neo4j/graphql` will **not** trigger subscriptions.
 
 For example:
 
@@ -29,7 +31,11 @@ import { Neo4jGraphQL, Neo4jGraphQLSubscriptionsCDCEngine } from '@neo4j/graphql
 
 const engine = new Neo4jGraphQLSubscriptionsCDCEngine({
     driver,
-    pollTime: 5000
+    pollTime: 5000,
+    queryConfig: {
+        database: "neo4j",
+    },
+    onlyGraphQLEvents: true
 })
 
 const neoSchema = new Neo4jGraphQL({
@@ -37,9 +43,6 @@ const neoSchema = new Neo4jGraphQL({
     driver,
     features: {
         subscriptions: engine,
-        queryConfig: {
-             database: "neo4j",
-        }
     },
 });
 ----

--- a/modules/ROOT/pages/subscriptions/customize-cdc.adoc
+++ b/modules/ROOT/pages/subscriptions/customize-cdc.adoc
@@ -20,8 +20,8 @@ Note that poll time is the period between a finished request and the start of th
 The actual time it takes for CDC events to trigger the subscription also depends on your network.
 * `queryConfig`: An object with the driver query options to be passed to CDC requests. 
 Use the `db` field to define the target database for CDC.
-* `onlyGraphQLEvents`: By default, subscriptions capture all changes done to the database. If this flag is set to true, only changes made through GraphQL will trigger the subscription.
-    * Note: If this flag is set to true, changes made with a different version of the `@neo4j/graphql` will **not** trigger subscriptions.
+* `onlyGraphQLEvents`: By default, subscriptions capture all changes done to the database. If this flag is set to `true`, only changes made through GraphQL will trigger the subscription.
+Note that if this flag is set to `true`, changes made with a different version of the `@neo4j/graphql` will not trigger subscriptions.
 
 For example:
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `6.x` to `7.x`:
 - [Merge pull request #221 from neo4j/update-cdc-docs](https://github.com/neo4j/docs-graphql/pull/221)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)