### PR TITLE
Add addVersionPrefix option in the Getting Started guide

### DIFF
--- a/modules/ROOT/pages/getting-started/index.adoc
+++ b/modules/ROOT/pages/getting-started/index.adoc
@@ -128,12 +128,24 @@ const server = new ApolloServer({
     schema: await neoSchema.getSchema(),
 });
 
+
 const { url } = await startStandaloneServer(server, {
+    context: async ({ req }) => ({
+        req,
+        cypherQueryOptions: {
+            addVersionPrefix: true,
+        },
+    }),
     listen: { port: 4000 },
 });
 
 console.log(`🚀 Server ready at ${url}`);
 ----
+
+[NOTE]
+====
+If you are using Neo4j 4.x, set the value of `addVersionPrefix` to false. Note that this may cause issues with AuraDB or Neo4j 2025 instances.
+====
 
 == Start the server
 
@@ -171,7 +183,12 @@ const server = new ApolloServer({
 });
 
 const { url } = await startStandaloneServer(server, {
-    context: async ({ req }) => ({ req }),
+    context: async ({ req }) => ({
+        req,
+        cypherQueryOptions: {
+            addVersionPrefix: true,
+        },
+    }),
     listen: { port: 4000 },
 });
 


### PR DESCRIPTION
The best practice for LTS is to set the `addVersionPrefix` option, to keep compatibility with Neo4j 2025 and AuraDB

This PR updates the getting started guide with the recommended option

This change is not needed on 7.x, as it is already enabled by default