### PR TITLE
adds a note about using aggregate with pagination

### DIFF
--- a/modules/ROOT/pages/queries-aggregations/aggregations.adoc
+++ b/modules/ROOT/pages/queries-aggregations/aggregations.adoc
@@ -225,9 +225,10 @@ query {
 ----
 
 
-== A note about aggregate with pagination
+== Aggregations and pagination
 
-Because aggregate is done within the `Connection` type, the optional arguments `first` and `after` are available for pagination. However, pagination **does not** apply to aggregate
+Since aggregations are done within the `Connection` type, the optional arguments `first` and `after` are available for pagination.
+However, pagination **does not** apply to aggregations.
 
 For example:
 
@@ -244,7 +245,7 @@ query {
 }
 ----
 
-The result would return the count of all the nodes:
+The result returns the count of all the nodes:
 
 [source, json, indent=0]
 ----

--- a/modules/ROOT/pages/queries-aggregations/aggregations.adoc
+++ b/modules/ROOT/pages/queries-aggregations/aggregations.adoc
@@ -49,8 +49,10 @@ Aggregations on a type are provided in the field `aggregate` inside Connection:
 query {
     usersConnection {
         aggregate {
-            name {
-                longest
+            node {
+                name {
+                    longest
+                }
             }
         }
     }
@@ -94,8 +96,10 @@ a|
 query {
     postsConnection {
         aggregate {
-            createdAt {
-                min
+            node {
+                createdAt {
+                    min
+                }
             }
         }
     }
@@ -219,4 +223,40 @@ query {
     }
 }
 ----
+
+
+== A note about aggregate with pagination
+
+Because aggregate is done within the `Connection` type, the optional arguments `first` and `after` are available for pagination. However, pagination **does not** apply to aggregate
+
+For example:
+
+[source, graphql, indent=0]
+----
+query {
+    usersConnection(first: 10) {
+        aggregate {
+            count {
+                nodes
+            }
+        }
+    }
+}
+----
+
+The result would return the count of all the nodes:
+
+[source, json, indent=0]
+----
+{
+    "usersConnection": {
+        "aggregate": {
+            "count": {
+                "nodes": 38
+            }
+        }
+    }
+}
+----
+
 


### PR DESCRIPTION
Adds a note about the behaviour of `aggregate` when using `first` and `after` pagination.

This PR also fixes two incorrect examples of aggregate

This is a draft PR until we confirm this is the desired behaviour