### PR TITLE
fix syntax for page-aliases

### DIFF
--- a/modules/ROOT/pages/relationships/single-relationships.adoc
+++ b/modules/ROOT/pages/relationships/single-relationships.adoc
@@ -1,6 +1,6 @@
 [[single-relationships]]
 = Single relationships and cardinality considerations
-:page-aliases: relationships/relationships.adoc relationships/single-relationships.adoc
+:page-aliases: relationships/relationships.adoc, relationships/single-relationships.adoc
 :description: This page describes the ways to interact with a Neo4j single relationship in the GraphQL schema.
 
 Single relationships are relationships that are modeled as a non-list type field on either side of the relationship. 


### PR DESCRIPTION
The list should be comma-separated. The space results in an error in the aliases-redirects extension (aside: we will update the extension to check for and log this error, instead of just failing!)