### PR TITLE
DOCOPS-161 Harden auto-backport.yml (add explicit contents:read permissions)

### DIFF
--- a/.github/workflows/auto-backport.yml
+++ b/.github/workflows/auto-backport.yml
@@ -1,4 +1,8 @@
 name: auto-cherry-pick
+
+permissions:
+  contents: read
+
 on:
   pull_request_target:
     types: ["labeled", "closed"]


### PR DESCRIPTION
## What

Adds an explicit `permissions: contents: read` block to `.github/workflows/auto-backport.yml`.

## Why

This workflow runs on `pull_request_target`, which otherwise hands the job a *write*-scoped `GITHUB_TOKEN`. The backport step uses `DOCS_AUTO_CP_TOKEN` (a PAT), so the default token needs nothing — `contents: read` is set as an explicit least-privilege floor. (The `sorenlouv/backport-github-action` is already SHA-pinned.)

Resolves the CodeQL `actions/missing-workflow-permissions` alert on this file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
