### PR TITLE
Add warning sections for authentication and authorization directives

### DIFF
--- a/modules/ROOT/pages/security/authentication.adoc
+++ b/modules/ROOT/pages/security/authentication.adoc
@@ -101,6 +101,37 @@ This is only evaluated under the following circumstances:
 * The `password` field is set on either `create` or `update`.
 * The `password` field is present in a selection set.
 
+[WARNING]
+====
+Field-level `@authentication` *does not* protect a field when it is used in a `where` filter or a `sort` argument.
+
+For example, given the type definition above, the following query is not protected by `@authentication`, even without a valid token:
+
+[source, graphql, indent=0]
+----
+query {
+    users(where: { password: { startsWith: "$2b$10$a" } }) {
+        id
+    }
+}
+----
+
+A non-empty result confirms the guess is correct, and an attacker can repeat this one character at a time to reconstruct the entire field value.
+Sorting on the field (`sort: [{ password: ASC }]`) similarly leaks the relative ordering of every value.
+
+To prevent a protected field from being filtered or sorted on, add the xref:directives/schema-configuration/field-configuration.adoc#_filterable[`@filterable`] and xref:directives/schema-configuration/field-configuration.adoc#_sortable[`@sortable`] directive.
+
+[source, graphql, indent=0]
+----
+type User @node {
+    id: ID!
+    name: String!
+    password: String! @authentication @sortable(byValue: false) @filterable(byValue: false, byAggregate: false)
+}
+----
+
+====
+
 
 == Additional verification
 

--- a/modules/ROOT/pages/security/authorization.adoc
+++ b/modules/ROOT/pages/security/authorization.adoc
@@ -299,7 +299,7 @@ type User @node {
     id: ID!
     username: String!
     password: String!
-        @authorization(validate: [{ operations: [UPDATE], where: { jwt: { roles: { includes: "admin" } } } }])
+        @authorization(validate: [{ operations: [READ, UPDATE], where: { node: { id: { eq: "$jwt.sub" } } } }])}])
         @sortable(byValue: false)
         @filterable(byValue: false, byAggregate: false)
 }

--- a/modules/ROOT/pages/security/authorization.adoc
+++ b/modules/ROOT/pages/security/authorization.adoc
@@ -273,6 +273,40 @@ However, consider the following query:
 This will require a valid JWT to have been provided with the request, and the matching users will be filtered down according to the JWT subject.
 The same applies for attempting to update the `password` field, the update will only apply to the user matching the JWT.
 
+[WARNING]
+====
+Field-level `@authorization` *does not* protect a field when it is used in a `where` filter or a `sort` argument.
+
+For example, given the type definition above, the following query is not protected by `@authorization`, even without a valid JWT:
+
+[source, graphql, indent=0]
+----
+query {
+    users(where: { password: { startsWith: "$2b$10$a" } }) {
+        id
+    }
+}
+----
+
+A non-empty result confirms the guess is correct, and an attacker can repeat this one character at a time to reconstruct the entire field value.
+Sorting on the field (`sort: [{ password: ASC }]`) similarly leaks the relative ordering of every value.
+
+To prevent a protected field from being filtered or sorted on, add the xref:directives/schema-configuration/field-configuration.adoc#_filterable[`@filterable`] and xref:directives/schema-configuration/field-configuration.adoc#_sortable[`@sortable`] directive.
+
+[source, graphql, indent=0]
+----
+type User @node {
+    id: ID!
+    username: String!
+    password: String!
+        @authorization(validate: [{ operations: [UPDATE], where: { jwt: { roles: { includes: "admin" } } } }])
+        @sortable(byValue: false)
+        @filterable(byValue: false, byAggregate: false)
+}
+----
+
+====
+
 
 == Authorization without authentication
 


### PR DESCRIPTION
Include warnings in the documentation to clarify that field-level `@authentication` and `@authorization` do not protect fields when used in `where` filters or `sort` arguments. This aims to prevent potential security vulnerabilities by informing users about the risks associated with these directives.