### PR TITLE
Document subscription authentication and provide examples

### DIFF
--- a/modules/ROOT/pages/security/configuration.adoc
+++ b/modules/ROOT/pages/security/configuration.adoc
@@ -140,83 +140,13 @@ const { url } = await startStandaloneServer(server, {
 `customImplementation` is a placeholder for a function that provides a decoded JWT.
 Using `jwt` instead of `token` in the `context` informs the Neo4j GraphQL Library that it doesn't need to decode it.
 
-=== Subscriptions
-
-Subscriptions are served over a WebSocket connection rather than a regular HTTP request, so there is no `Authorization` header to read from once the connection is established.
-Instead, the token (or an already-decoded set of claims) is passed into the context object returned by the `context` function given to `useServer` from `graphql-ws`.
-
-==== Clients sending a token
-
-Clients send their token as part of `connectionParams` when the WebSocket connection is created.
-This is the expected channel for a client to authenticate a subscription — it plays the same role that the `Authorization` header plays for a regular HTTP request:
-
-[source, javascript, indent=0]
-----
-import { createClient } from "graphql-ws";
-
-const client = createClient({
-    url: "ws://localhost:4000/graphql",
-    connectionParams: () => ({
-        // Send the exact same JWT here that you would otherwise put in an
-        // `Authorization` header — `connectionParams` is the WebSocket
-        // equivalent of a request header.
-        token: "Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJyb2xlcyI6WyJhZG1pbiJdLCJpYXQiOjE3ODU5MjQ2OTJ9.pDddhOtjvuV9VPR3-0XGoQ5dybwMobVB2H72eaPgeG8",
-    }),
-});
-----
-
-On the server, `connectionParams` are exposed on the connection context (`ctx`) that `graphql-ws` passes into the `context` function.
-Extract the token from there and assign it to the `token` field, exactly as `req.headers.authorization` is assigned for a regular HTTP request:
-
-[source, javascript, indent=0]
-----
-const serverCleanup = useServer(
-    {
-        schema,
-        context: (ctx) => {
-            return {
-                ...ctx,
-                token: ctx.connectionParams?.token,
-            };
-        },
-    },
-    wsServer
-);
-----
-
-The Neo4j GraphQL Library then decodes and verifies this token in exactly the same way as it does for HTTP requests, see xref:#_encoded_jwts[].
-
-==== Server-injected claims
-
-A server owner can also bypass client-sent tokens altogether and inject already-verified claims directly into the `jwt` field of the WebSocket context.
-This is useful, for example, for internal or trusted connections where the server itself determines the caller's identity rather than trusting a token supplied by the client.
-
 [WARNING]
 ====
-Claims injected this way are trusted implicitly by the Neo4j GraphQL Library — they are *not* decoded or verified again.
-Only use this pattern for claims that the server owner has already verified through some other mechanism.
+Claims passed in this way are trusted implicitly by the Neo4j GraphQL Library — they are *not* decoded or verified again.
+Only use this pattern for claims that have already been verified through some other mechanism.
 ====
 
-[source, javascript, indent=0]
-----
-const serverCleanup = useServer(
-    {
-        schema,
-        context: (ctx) => {
-            return {
-                ...ctx,
-                // JWT set by the server owner (trusted) — the sanctioned channel
-                // for a developer-injected identity on subscriptions. These claims
-                // must already be verified by the server owner.
-                jwt: {
-                    roles: ["admin"],
-                },
-            };
-        },
-    },
-    wsServer
-);
-----
+For how JWTs are authenticated on subscriptions specifically, see xref:security/subscriptions-authorization.adoc#_authenticating_subscriptions[Authenticating subscriptions].
 
 == Adding JWT claims
 

--- a/modules/ROOT/pages/security/configuration.adoc
+++ b/modules/ROOT/pages/security/configuration.adoc
@@ -140,6 +140,84 @@ const { url } = await startStandaloneServer(server, {
 `customImplementation` is a placeholder for a function that provides a decoded JWT.
 Using `jwt` instead of `token` in the `context` informs the Neo4j GraphQL Library that it doesn't need to decode it.
 
+=== Subscriptions
+
+Subscriptions are served over a WebSocket connection rather than a regular HTTP request, so there is no `Authorization` header to read from once the connection is established.
+Instead, the token (or an already-decoded set of claims) is passed into the context object returned by the `context` function given to `useServer` from `graphql-ws`.
+
+==== Clients sending a token
+
+Clients send their token as part of `connectionParams` when the WebSocket connection is created.
+This is the expected channel for a client to authenticate a subscription — it plays the same role that the `Authorization` header plays for a regular HTTP request:
+
+[source, javascript, indent=0]
+----
+import { createClient } from "graphql-ws";
+
+const client = createClient({
+    url: "ws://localhost:4000/graphql",
+    connectionParams: () => ({
+        // Send the exact same JWT here that you would otherwise put in an
+        // `Authorization` header — `connectionParams` is the WebSocket
+        // equivalent of a request header.
+        token: "Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJyb2xlcyI6WyJhZG1pbiJdLCJpYXQiOjE3ODU5MjQ2OTJ9.pDddhOtjvuV9VPR3-0XGoQ5dybwMobVB2H72eaPgeG8",
+    }),
+});
+----
+
+On the server, `connectionParams` are exposed on the connection context (`ctx`) that `graphql-ws` passes into the `context` function.
+Extract the token from there and assign it to the `token` field, exactly as `req.headers.authorization` is assigned for a regular HTTP request:
+
+[source, javascript, indent=0]
+----
+const serverCleanup = useServer(
+    {
+        schema,
+        context: (ctx) => {
+            return {
+                ...ctx,
+                token: ctx.connectionParams?.token,
+            };
+        },
+    },
+    wsServer
+);
+----
+
+The Neo4j GraphQL Library then decodes and verifies this token in exactly the same way as it does for HTTP requests, see xref:#_encoded_jwts[].
+
+==== Server-injected claims
+
+A server owner can also bypass client-sent tokens altogether and inject already-verified claims directly into the `jwt` field of the WebSocket context.
+This is useful, for example, for internal or trusted connections where the server itself determines the caller's identity rather than trusting a token supplied by the client.
+
+[WARNING]
+====
+Claims injected this way are trusted implicitly by the Neo4j GraphQL Library — they are *not* decoded or verified again.
+Only use this pattern for claims that the server owner has already verified through some other mechanism.
+====
+
+[source, javascript, indent=0]
+----
+const serverCleanup = useServer(
+    {
+        schema,
+        context: (ctx) => {
+            return {
+                ...ctx,
+                // JWT set by the server owner (trusted) — the sanctioned channel
+                // for a developer-injected identity on subscriptions. These claims
+                // must already be verified by the server owner.
+                jwt: {
+                    roles: ["admin"],
+                },
+            };
+        },
+    },
+    wsServer
+);
+----
+
 == Adding JWT claims
 
 By default, filtering is available on https://www.rfc-editor.org/rfc/rfc7519#section-4.1[the registered claim names] in the JWT specification.

--- a/modules/ROOT/pages/security/configuration.adoc
+++ b/modules/ROOT/pages/security/configuration.adoc
@@ -205,9 +205,6 @@ const serverCleanup = useServer(
         context: (ctx) => {
             return {
                 ...ctx,
-                // JWT set by the server owner (trusted) — the sanctioned channel
-                // for a developer-injected identity on subscriptions. These claims
-                // must already be verified by the server owner.
                 jwt: {
                     roles: ["admin"],
                 },

--- a/modules/ROOT/pages/security/configuration.adoc
+++ b/modules/ROOT/pages/security/configuration.adoc
@@ -189,7 +189,7 @@ The Neo4j GraphQL Library then decodes and verifies this token in exactly the sa
 ==== Server-injected claims
 
 A server owner can also bypass client-sent tokens altogether and inject already-verified claims directly into the `jwt` field of the WebSocket context.
-This is useful, for example, for internal or trusted connections where the server itself determines the caller's identity rather than trusting a token supplied by the client.
+This is useful, for example, if you need to support an authentication mechanism not supported by the Neo4j GraphQL library. You can perform the verification within the context and then pass the trusted claims to the Neo4j GraphQL library.
 
 [WARNING]
 ====

--- a/modules/ROOT/pages/security/subscriptions-authorization.adoc
+++ b/modules/ROOT/pages/security/subscriptions-authorization.adoc
@@ -8,16 +8,82 @@ Data APIs created in Aura Console currently do not support the `subscriptionsAut
 ====
 
 Subscriptions require their own authorization rules, which are configured with the `@subscriptionsAuthorization` directive.
-These rules are different to authorization rules for queries and mutations because they use filtering rules available for subscriptions events. 
+These rules are different to authorization rules for queries and mutations because they use filtering rules available for subscriptions events.
 These filtering rules can only be used to filter against the properties of the nodes impacted by the events.
+
+See xref:subscriptions/index.adoc[Subscriptions] for how to set up subscriptions in general.
 
 All subscriptions authorization rules have an implied requirement for authentication, given that the rules are normally evaluated against values in the JWT payload.
 
-[NOTE]
+== Authenticating subscriptions
+
+Subscription operations never go through the Apollo/HTTP `context` function.
+They are served over a WebSocket connection and handled entirely by the WebSocket server, so they run the `context` function passed to `useServer` from `graphql-ws` instead.
+Because of this, there is no `Authorization` header to read a token from once the connection is established — the token (or an already-decoded set of claims) has to be passed into that WebSocket context some other way.
+
+=== Clients sending a token
+
+Clients send their token as part of `connectionParams` when the WebSocket connection is created.
+This is the expected channel for a client to authenticate a subscription — it plays the same role that the `Authorization` header plays for a regular HTTP request:
+
+[source, javascript, indent=0]
+----
+import { createClient } from "graphql-ws";
+
+const client = createClient({
+    url: "ws://localhost:4000/graphql",
+    connectionParams: () => ({
+        // Send the exact same JWT here that you would otherwise put in an
+        // `Authorization` header — `connectionParams` is the WebSocket
+        // equivalent of a request header.
+        token: "Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJyb2xlcyI6WyJhZG1pbiJdLCJpYXQiOjE3ODU5MjQ2OTJ9.pDddhOtjvuV9VPR3-0XGoQ5dybwMobVB2H72eaPgeG8",
+    }),
+});
+----
+
+On the server, no extra mapping is required to pick this up — the Neo4j GraphQL Library reads the token directly from `connectionParams`, so the default `context` function shown in xref:subscriptions/getting-started.adoc[Getting started] is already enough:
+
+[source, javascript, indent=0]
+----
+const serverCleanup = useServer(
+    {
+        schema,
+        context: (ctx) => ctx,
+    },
+    wsServer
+);
+----
+
+The Neo4j GraphQL Library then decodes and verifies this token in exactly the same way as it does for HTTP requests, see xref:security/configuration.adoc#_encoded_jwts[].
+
+=== Server-injected claims
+
+A server owner can also bypass client-sent tokens altogether and inject already-verified claims directly into the WebSocket context.
+This is useful, for example, if you need to support an authentication mechanism not supported by the Neo4j GraphQL library. You can perform the verification within the context and then pass the trusted claims to the Neo4j GraphQL library.
+
+[WARNING]
 ====
-Subscriptions run over a WebSocket connection, so there is no `Authorization` header to populate the JWT payload from.
-See xref:security/configuration.adoc#_subscriptions[Subscriptions] for how clients send a token and how a server owner can inject claims directly for subscription connections.
+Claims injected this way are trusted implicitly by the Neo4j GraphQL Library — they are *not* decoded or verified again.
+Only use this pattern for claims that the server owner has already verified through some other mechanism.
 ====
+
+[source, javascript, indent=0]
+----
+const serverCleanup = useServer(
+    {
+        schema,
+        context: (ctx) => {
+            return {
+                ...ctx,
+                jwt: {
+                    roles: ["admin"],
+                },
+            };
+        },
+    },
+    wsServer
+);
+----
 
 == Filtering rules
 

--- a/modules/ROOT/pages/security/subscriptions-authorization.adoc
+++ b/modules/ROOT/pages/security/subscriptions-authorization.adoc
@@ -19,9 +19,11 @@ All subscriptions authorization rules have an implied requirement for authentica
 
 Subscription operations never go through the Apollo/HTTP `context` function.
 They are served over a WebSocket connection and handled entirely by the WebSocket server, so they run the `context` function passed to `useServer` from `graphql-ws` instead.
-Because of this, there is no `Authorization` header to read a token from once the connection is established — the token (or an already-decoded set of claims) has to be passed into that WebSocket context some other way.
+Because of this, there is no `Authorization` header to read a token from once the connection is established.
 
-=== Clients sending a token
+Just as with regular HTTP requests, the Neo4j GraphQL Library accepts both xref:security/configuration.adoc#_encoded_jwts[encoded] and xref:security/configuration.adoc#_decoded_jwts[decoded] JWTs on subscription connections — only the channel they travel over is different.
+
+=== Encoded JWTs: clients sending a token
 
 Clients send their token as part of `connectionParams` when the WebSocket connection is created.
 This is the expected channel for a client to authenticate a subscription — it plays the same role that the `Authorization` header plays for a regular HTTP request:
@@ -41,7 +43,7 @@ const client = createClient({
 });
 ----
 
-On the server, no extra mapping is required to pick this up — the Neo4j GraphQL Library reads the token directly from `connectionParams`, so the default `context` function shown in xref:subscriptions/getting-started.adoc[Getting started] is already enough:
+On the server, no extra mapping is required to pick this up — the Neo4j GraphQL Library reads the `token` directly from `connectionParams`, so the default `context` function shown in xref:subscriptions/getting-started.adoc[Getting started] is already enough:
 
 [source, javascript, indent=0]
 ----
@@ -54,11 +56,11 @@ const serverCleanup = useServer(
 );
 ----
 
-The Neo4j GraphQL Library then decodes and verifies this token in exactly the same way as it does for HTTP requests, see xref:security/configuration.adoc#_encoded_jwts[].
+The Neo4j GraphQL Library then decodes and verifies this token in exactly the same way as it does for xref:security/configuration.adoc#_encoded_jwts[encoded JWTs on HTTP requests].
 
-=== Server-injected claims
+=== Decoded JWTs: server-injected claims
 
-A server owner can also bypass client-sent tokens altogether and inject already-verified claims directly into the WebSocket context.
+A server owner can also bypass client-sent tokens altogether and inject an already-decoded set of claims directly into the WebSocket context — the subscriptions equivalent of passing a xref:security/configuration.adoc#_decoded_jwts[decoded JWT] on an HTTP request.
 This is useful, for example, if you need to support an authentication mechanism not supported by the Neo4j GraphQL library. You can perform the verification within the context and then pass the trusted claims to the Neo4j GraphQL library.
 
 [WARNING]

--- a/modules/ROOT/pages/security/subscriptions-authorization.adoc
+++ b/modules/ROOT/pages/security/subscriptions-authorization.adoc
@@ -18,15 +18,31 @@ All subscriptions authorization rules have an implied requirement for authentica
 == Authenticating subscriptions
 
 Subscription operations never go through the Apollo/HTTP `context` function.
-They are served over a WebSocket connection and handled entirely by the WebSocket server, so they run the `context` function passed to `useServer` from `graphql-ws` instead.
+They are served over a WebSocket connection and handled entirely by the WebSocket server, so authentication has to happen in the context function of whichever WebSocket server implementation is being used — for example, the `context` function passed to `useServer` from `graphql-ws`.
 Because of this, there is no `Authorization` header to read a token from once the connection is established.
 
 Just as with regular HTTP requests, the Neo4j GraphQL Library accepts both xref:security/configuration.adoc#_encoded_jwts[encoded] and xref:security/configuration.adoc#_decoded_jwts[decoded] JWTs on subscription connections — only the channel they travel over is different.
 
 === Encoded JWTs: clients sending a token
 
-Clients send their token as part of `connectionParams` when the WebSocket connection is created.
-This is the expected channel for a client to authenticate a subscription — it plays the same role that the `Authorization` header plays for a regular HTTP request:
+On the server, no extra mapping is required to authenticate a token sent this way — the Neo4j GraphQL Library reads the `token` directly from `connectionParams`, so the default `context` function shown in xref:subscriptions/getting-started.adoc[Getting started] is already enough:
+
+[source, javascript, indent=0]
+----
+const serverCleanup = useServer(
+    {
+        schema,
+        context: (ctx) => ctx,
+    },
+    wsServer
+);
+----
+
+The Neo4j GraphQL Library then decodes and verifies this token in exactly the same way as it does for xref:security/configuration.adoc#_encoded_jwts[encoded JWTs on HTTP requests].
+
+On the client, the token is sent as part of `connectionParams` when the WebSocket connection is created.
+This is the expected channel for a client to authenticate a subscription — it plays the same role that the `Authorization` header plays for a regular HTTP request.
+The following example uses `graphql-ws`, but this is just one option — any WebSocket client library that supports sending `connectionParams` can be used the same way:
 
 [source, javascript, indent=0]
 ----
@@ -42,21 +58,6 @@ const client = createClient({
     }),
 });
 ----
-
-On the server, no extra mapping is required to pick this up — the Neo4j GraphQL Library reads the `token` directly from `connectionParams`, so the default `context` function shown in xref:subscriptions/getting-started.adoc[Getting started] is already enough:
-
-[source, javascript, indent=0]
-----
-const serverCleanup = useServer(
-    {
-        schema,
-        context: (ctx) => ctx,
-    },
-    wsServer
-);
-----
-
-The Neo4j GraphQL Library then decodes and verifies this token in exactly the same way as it does for xref:security/configuration.adoc#_encoded_jwts[encoded JWTs on HTTP requests].
 
 === Decoded JWTs: server-injected claims
 
@@ -75,17 +76,19 @@ const serverCleanup = useServer(
     {
         schema,
         context: (ctx) => {
+            const jwt = customImplementation(ctx);
+
             return {
                 ...ctx,
-                jwt: {
-                    roles: ["admin"],
-                },
+                jwt,
             };
         },
     },
     wsServer
 );
 ----
+
+`customImplementation` is a placeholder for a function that provides a decoded JWT, in the same way as it does for xref:security/configuration.adoc#_decoded_jwts[decoded JWTs on HTTP requests] — for example, verifying a token found elsewhere on `ctx` using a mechanism not supported by the Neo4j GraphQL Library, and returning the resulting claims, such as `{ sub: "user1234" }`.
 
 == Filtering rules
 

--- a/modules/ROOT/pages/security/subscriptions-authorization.adoc
+++ b/modules/ROOT/pages/security/subscriptions-authorization.adoc
@@ -13,6 +13,12 @@ These filtering rules can only be used to filter against the properties of the n
 
 All subscriptions authorization rules have an implied requirement for authentication, given that the rules are normally evaluated against values in the JWT payload.
 
+[NOTE]
+====
+Subscriptions run over a WebSocket connection, so there is no `Authorization` header to populate the JWT payload from.
+See xref:security/configuration.adoc#_subscriptions[Subscriptions] for how clients send a token and how a server owner can inject claims directly for subscription connections.
+====
+
 == Filtering rules
 
 Filtering rules prevent events which contain information that users don't have access to from reaching them - they will receive no indication that this is the case.

--- a/modules/ROOT/pages/subscriptions/getting-started.adoc
+++ b/modules/ROOT/pages/subscriptions/getting-started.adoc
@@ -139,7 +139,7 @@ main();
 
 == GraphQL subscriptions
 
-With the previous server running, the available subscriptions are set for `Movie` and `Actor`. 
+With the previous server running, the available subscriptions are set for `Movie` and `Actor`.
 You can subscribe to new movies created with the following statement:
 
 [source, graphql, indent=0]
@@ -153,7 +153,7 @@ subscription {
 }
 ----
 
-With that, any new movie created with the matching title will trigger a subscription. 
+With that, any new movie created with the matching title will trigger a subscription.
 You can try this with the following query:
 
 [source, graphql, indent=0]
@@ -166,3 +166,42 @@ mutation {
     }
 }
 ----
+
+== Connecting a client
+
+To run subscriptions from a client, connect to the server with a `graphql-ws` client rather than a regular HTTP GraphQL client:
+
+[source, bash]
+----
+npm i --save graphql-ws
+----
+
+[source, javascript, indent=0]
+----
+import { createClient } from "graphql-ws";
+
+const client = createClient({
+    url: "ws://localhost:4000/graphql",
+});
+
+const dispose = client.subscribe(
+    {
+        query: `
+            subscription {
+                movieCreated(where: { title: { eq: "The Matrix" } }) {
+                    createdMovie {
+                        title
+                    }
+                }
+            }
+        `,
+    },
+    {
+        next: (data) => console.log(data),
+        error: (err) => console.error(err),
+        complete: () => console.log("Subscription complete"),
+    }
+);
+----
+
+For how to authenticate this connection, see xref:security/subscriptions-authorization.adoc#_authenticating_subscriptions[Authenticating subscriptions].


### PR DESCRIPTION
Enhance documentation on subscription authentication by detailing client token usage via `connectionParams` and server-injected claims. Include examples for connecting clients with subscriptions and clarify the distinction between decoded and encoded JWTs.